### PR TITLE
android: don't crash when callback not registered

### DIFF
--- a/android/src/main/kotlin/io/flutter/plugins/geofencing/GeofencingService.kt
+++ b/android/src/main/kotlin/io/flutter/plugins/geofencing/GeofencingService.kt
@@ -61,6 +61,10 @@ class GeofencingService : MethodCallHandler, JobIntentService() {
                         GeofencingPlugin.SHARED_PREFERENCES_KEY,
                         Context.MODE_PRIVATE)
                         .getLong(GeofencingPlugin.CALLBACK_DISPATCHER_HANDLE_KEY, 0)
+                if (callbackHandle == 0) {
+                    Log.e(TAG, "Fatal: no callback registered")
+                    return
+                }
 
                 val callbackInfo = FlutterCallbackInformation.lookupCallbackInformation(callbackHandle)
                 if (callbackInfo == null) {


### PR DESCRIPTION
It happens sometimes that when an app is uninstalled and reinstalled,
or app data is cleared, that the geofencing framework calls our service
and the callback is not registered yet, causing a crash.